### PR TITLE
fix: only test enabled features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ocpp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "jsonschema",

--- a/src/tests/schema_validation/mod.rs
+++ b/src/tests/schema_validation/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(test)]
+#[cfg(all(test, feature = "v1_6"))]
 mod v1_6;
-#[cfg(test)]
+#[cfg(all(test, feature = "v2_0_1"))]
 mod v2_0_1;


### PR DESCRIPTION
All features was tested regadless of the features enabled which lead to issues when running `cargo test` without the `--all-features` flag.