### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish to crates.io
 
 on:
   workflow_dispatch: {}
+  release:
+    types:
+      - published
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -170,3 +170,9 @@ Additionally, adhere to the existing testing conventions and follow the code sty
 Use `rustfmt` before you PR.
 
 pre-commit config is available. You can read more about it at [pre-commits](https://pre-commit.com) website and checkout their repo on [github](https://github.com/pre-commit/pre-commit)
+
+## Releasing a new version
+1. Update the version of the library and push the changes to the main branch.
+2. Create a [new release](https://github.com/codelabsab/rust-ocpp/releases/new) on GitHub with the new version number and some release notes (optional).
+
+This will trigger the [publish workflow](./.github/workflows/publish.yml) which will publish the new version to crates.io.


### PR DESCRIPTION
We should use the github `Releases` to make it easier for users of this
library to compare the differences between versions etc.

Relates to #58 (thanks @shepmaster for the suggestion)