### PR TITLE
Replace deprecated GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: install llvm tools preview
         run: rustup component add llvm-tools-preview
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features --verbose
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --release --all-features
 
       # test
       - name: Run tests
@@ -32,4 +30,3 @@ jobs:
         with:
           registry-token: ${{ secrets.CARGO_TOKEN }}
           check-repo: false
-


### PR DESCRIPTION
Use new github action to build the package.

Fixes #72 