### PR TITLE
The v1.6 version of AuthorizationData is missing the #[serde(rename_all = "camelCase")] attribute needed to rename the fields to match the v1.6 specification.

### DIFF
--- a/src/v1_6/types/authorization_data.rs
+++ b/src/v1_6/types/authorization_data.rs
@@ -3,6 +3,7 @@ use validator::Validate;
 
 /// Elements that constitute an entry of a Local Authorization List update.
 #[derive(serde::Serialize, serde::Deserialize, Validate, Debug, Clone, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthorizationData {
     /// Required. The identifier to which this authorization applies.
     #[validate(length(min = 1, max = 20))]


### PR DESCRIPTION
Fixes issues #98