### PR TITLE
Replace f32 usage with Decimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,17 @@ version = 3
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
@@ -52,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,10 +102,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+ "syn_derive",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
 
 [[package]]
 name = "bytecount"
@@ -97,10 +172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
-name = "bytes"
-version = "1.2.1"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
@@ -116,6 +197,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -178,6 +265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +311,12 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -281,6 +380,21 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hermit-abi"
@@ -410,6 +524,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,7 +569,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14a655181740aa66dfcb182daca1bc8109fda5c7c0399c4f30dcb155ab0d32a6"
 dependencies = [
- "ahash",
+ "ahash 0.8.0",
  "anyhow",
  "base64",
  "bytecount",
@@ -737,6 +861,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +893,15 @@ checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -796,12 +938,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -843,6 +1041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +1086,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.103",
+]
+
+[[package]]
 name = "rust-ocpp"
 version = "1.0.4"
 dependencies = [
@@ -886,10 +1122,38 @@ dependencies = [
  "jsonschema",
  "mockall",
  "regex",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da991f231869f34268415a49724c6578e740ad697ba0999199d6f22b3949332c"
+dependencies = [
+ "quote",
+ "rust_decimal",
 ]
 
 [[package]]
@@ -903,6 +1167,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
@@ -947,6 +1217,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1012,10 +1288,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termtree"
@@ -1079,6 +1373,23 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.4.7",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1543,6 +1854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,4 +1870,34 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.59",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,11 @@ chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
 uuid = { version = "1", default-features = false, features = ["v4"] }
 validator = { version = "0.18.1", default-features = false, features = ["derive"] }
 regex = "1.10.6"
+rust_decimal = { version = "1.36.0", features = ["serde-with-arbitrary-precision"] }
 
 [dev-dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["clock"] }
 serde_json = "1"
 mockall = "0.13.0"
 jsonschema = "0.19"
+rust_decimal_macros = "1.36.0"

--- a/src/tests/schema_validation/v1_6.rs
+++ b/src/tests/schema_validation/v1_6.rs
@@ -74,6 +74,7 @@ mod tests {
     };
     use chrono::Utc;
     use jsonschema::JSONSchema;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn validate_authorize() {
@@ -502,10 +503,10 @@ mod tests {
                 charging_rate_unit: ChargingRateUnitType::W,
                 charging_schedule_period: vec![ChargingSchedulePeriod {
                     start_period: 0,
-                    limit: 0.0,
+                    limit: dec!(0.0),
                     number_phases: Some(1),
                 }],
-                min_charging_rate: Some(1.0),
+                min_charging_rate: Some(dec!(1.0)),
             }),
         };
 
@@ -939,7 +940,7 @@ mod tests {
                     charging_rate_unit: ChargingRateUnitType::W,
                     charging_schedule_period: vec![ChargingSchedulePeriod {
                         start_period: 0,
-                        limit: 0.0,
+                        limit: dec!(0.0),
                         number_phases: None,
                     }],
                     min_charging_rate: None,

--- a/src/tests/schema_validation/v2_0_1.rs
+++ b/src/tests/schema_validation/v2_0_1.rs
@@ -300,6 +300,7 @@ mod tests {
     use crate::v2_0_1::messages::update_firmware::{UpdateFirmwareRequest, UpdateFirmwareResponse};
     use chrono::Utc;
     use jsonschema::JSONSchema;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn validate_authorize_request() {
@@ -780,7 +781,7 @@ mod tests {
     #[test]
     fn validate_cost_updated_request() {
         let test = CostUpdatedRequest {
-            total_cost: 0.0,
+            total_cost: dec!(0.0),
             transaction_id: "".to_string(),
         };
         let schema = include_str!("schemas/v2.0.1/CostUpdatedRequest.json");
@@ -1203,7 +1204,7 @@ mod tests {
                 charging_rate_unit: ChargingRateUnitEnumType::W,
                 charging_schedule_period: vec![ChargingSchedulePeriodType {
                     start_period: 0,
-                    limit: 0.0,
+                    limit: dec!(0.0),
                     number_phases: Some(1),
                     phase_to_use: Some(1),
                 }],
@@ -1739,7 +1740,7 @@ mod tests {
             meter_value: vec![MeterValueType {
                 timestamp: Utc::now(),
                 sampled_value: vec![SampledValueType {
-                    value: 0.0,
+                    value: dec!(0.0),
                     context: Some(ReadingContextEnumType::SampleClock),
                     measurand: Some(MeasurandEnumType::CurrentExport),
                     phase: Some(PhaseEnumType::L1),
@@ -1799,10 +1800,10 @@ mod tests {
                 start_schedule: Some(Utc::now()),
                 duration: Some(10),
                 charging_rate_unit: ChargingRateUnitEnumType::W,
-                min_charging_rate: Some(10.0),
+                min_charging_rate: Some(dec!(10.0)),
                 charging_schedule_period: vec![ChargingSchedulePeriodType {
                     start_period: 0,
-                    limit: 0.0,
+                    limit: dec!(0.0),
                     number_phases: Some(0),
                     phase_to_use: Some(0),
                 }],
@@ -2022,10 +2023,10 @@ mod tests {
                 start_schedule: Some(Utc::now()),
                 duration: Some(0),
                 charging_rate_unit: ChargingRateUnitEnumType::W,
-                min_charging_rate: Some(0.0),
+                min_charging_rate: Some(dec!(0.0)),
                 charging_schedule_period: vec![ChargingSchedulePeriodType {
                     start_period: 0,
-                    limit: 0.0,
+                    limit: dec!(0.0),
                     number_phases: Some(0),
                     phase_to_use: Some(0),
                 }],
@@ -2170,7 +2171,7 @@ mod tests {
                 variable_monitoring: vec![VariableMonitoringType {
                     id: 0,
                     transaction: false,
-                    value: 0.0,
+                    value: dec!(0.0),
                     kind: MonitorEnumType::UpperThreshold,
                     severity: 0,
                 }],
@@ -2235,8 +2236,8 @@ mod tests {
                 variable_characteristics: Some(VariableCharacteristicsType {
                     unit: Some("unit".to_string()),
                     data_type: DataEnumType::String,
-                    min_limit: Some(0.0),
-                    max_limit: Some(0.0),
+                    min_limit: Some(dec!(0.0)),
+                    max_limit: Some(dec!(0.0)),
                     values_list: Some("values_list".to_string()),
                     supports_monitoring: false,
                 }),
@@ -2373,10 +2374,10 @@ mod tests {
                     start_schedule: Some(Utc::now()),
                     duration: Some(1),
                     charging_rate_unit: ChargingRateUnitEnumType::W,
-                    min_charging_rate: Some(1.0),
+                    min_charging_rate: Some(dec!(1.0)),
                     charging_schedule_period: vec![ChargingSchedulePeriodType {
                         start_period: 0,
-                        limit: 0.0,
+                        limit: dec!(0.0),
                         number_phases: Some(1),
                         phase_to_use: Some(4),
                     }],
@@ -2460,10 +2461,10 @@ mod tests {
                     start_schedule: Some(Utc::now()),
                     duration: Some(1),
                     charging_rate_unit: ChargingRateUnitEnumType::W,
-                    min_charging_rate: Some(0.1),
+                    min_charging_rate: Some(dec!(0.1)),
                     charging_schedule_period: vec![ChargingSchedulePeriodType {
                         start_period: 0,
-                        limit: 0.0,
+                        limit: dec!(0.0),
                         number_phases: Some(1),
                         phase_to_use: Some(1),
                     }],
@@ -2836,10 +2837,10 @@ mod tests {
                     start_schedule: Some(Utc::now()),
                     duration: Some(0),
                     charging_rate_unit: ChargingRateUnitEnumType::W,
-                    min_charging_rate: Some(0.0),
+                    min_charging_rate: Some(dec!(0.0)),
                     charging_schedule_period: vec![ChargingSchedulePeriodType {
                         start_period: 0,
-                        limit: 0.0,
+                        limit: dec!(0.0),
                         number_phases: Some(0),
                         phase_to_use: Some(0),
                     }],
@@ -3110,7 +3111,7 @@ mod tests {
             set_monitoring_data: vec![SetMonitoringDataType {
                 id: Some(0),
                 transaction: Some(false),
-                value: 0.0,
+                value: dec!(0.0),
                 kind: MonitorEnumType::UpperThreshold,
                 severity: 0,
                 component: ComponentType {
@@ -3360,7 +3361,7 @@ mod tests {
             meter_value: Some(vec![MeterValueType {
                 timestamp: Utc::now(),
                 sampled_value: vec![SampledValueType {
-                    value: 0.0,
+                    value: dec!(0.0),
                     context: Some(ReadingContextEnumType::InterruptionBegin),
                     measurand: Some(MeasurandEnumType::CurrentExport),
                     phase: Some(PhaseEnumType::L1),
@@ -3394,7 +3395,7 @@ mod tests {
     #[test]
     fn validate_transaction_event_response() {
         let test = TransactionEventResponse {
-            total_cost: Some(0.0),
+            total_cost: Some(dec!(0.0)),
             charging_priority: Some(0),
             id_token_info: Some(IdTokenInfoType {
                 status: AuthorizationStatusEnumType::Accepted,

--- a/src/v1_6/types/charging_schedule.rs
+++ b/src/v1_6/types/charging_schedule.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 
 use super::{ChargingRateUnitType, ChargingSchedulePeriod};
 
@@ -18,5 +19,6 @@ pub struct ChargingSchedule {
     pub charging_schedule_period: Vec<ChargingSchedulePeriod>,
     /// Optional. Minimum charging rate supported by the electric vehicle. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_charging_rate: Option<f32>,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision_option")]
+    pub min_charging_rate: Option<Decimal>,
 }

--- a/src/v1_6/types/charging_schedule_period.rs
+++ b/src/v1_6/types/charging_schedule_period.rs
@@ -1,3 +1,5 @@
+use rust_decimal::Decimal;
+
 /// Charging schedule period structure defines a time period in a charging schedule, as used in: ChargingSchedule.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
@@ -5,7 +7,8 @@ pub struct ChargingSchedulePeriod {
     /// Required. Start of the period, in seconds from the start of schedule. The value of StartPeriod also defines the stop time of the previous period.
     pub start_period: i32,
     /// Required. Charging rate limit during the schedule period, in the applicable chargingRateUnit, for example in Amperes or Watts. Accepts at most one digit fraction (e.g. 8.1).
-    pub limit: f32,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision")]
+    pub limit: Decimal,
     /// Optional. The number of phases that can be used for charging. If a number of phases is needed, numberPhases=3 will be assumed unless another number is given.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number_phases: Option<i32>,

--- a/src/v2_0_1/datatypes/charging_schedule_period_type.rs
+++ b/src/v2_0_1/datatypes/charging_schedule_period_type.rs
@@ -1,3 +1,5 @@
+use rust_decimal::Decimal;
+
 /// Charging schedule period structure defines a time period in a charging schedule
 /// ChargingSchedulePeriodType is used by: Common:ChargingScheduleType , Common:CompositeScheduleType
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Default)]
@@ -6,7 +8,8 @@ pub struct ChargingSchedulePeriodType {
     /// Required. Start of the period, in seconds from the start of schedule. The value of StartPeriod also defines the stop time of the previous period.
     pub start_period: i32,
     /// Required. Charging rate limit during the schedule period, in the applicable chargingRateUnit, for example in Amperes (A) or Watts (W). Accepts at most one digit fraction (e.g. 8.1).
-    pub limit: f32,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision")]
+    pub limit: Decimal,
     /// Optional. The number of phases that can be used for charging. If a number of phases is needed, numberPhases=3 will be assumed unless another number is given.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number_phases: Option<i32>,

--- a/src/v2_0_1/datatypes/charging_schedule_type.rs
+++ b/src/v2_0_1/datatypes/charging_schedule_type.rs
@@ -1,5 +1,6 @@
 use chrono::DateTime;
 use chrono::Utc;
+use rust_decimal::Decimal;
 use validator::Validate;
 
 use super::charging_schedule_period_type::ChargingSchedulePeriodType;
@@ -23,7 +24,8 @@ pub struct ChargingScheduleType {
     pub charging_rate_unit: ChargingRateUnitEnumType,
     /// Optional. Minimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_charging_rate: Option<f32>,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision_option")]
+    pub min_charging_rate: Option<Decimal>,
     /// Required. List of ChargingSchedulePeriod elements defining maximum power or current usage over time. The maximum number of periods, that is supported by the Charging Station, if less than 1024, is set by device model variable SmartChargingCtrlr.PeriodsPerSchedule
     #[validate(length(min = 1))]
     pub charging_schedule_period: Vec<ChargingSchedulePeriodType>,

--- a/src/v2_0_1/datatypes/sampled_value_type.rs
+++ b/src/v2_0_1/datatypes/sampled_value_type.rs
@@ -1,3 +1,5 @@
+use rust_decimal::Decimal;
+
 use super::signed_meter_value_type::SignedMeterValueType;
 use super::unit_of_measure_type::UnitOfMeasureType;
 use crate::v2_0_1::enumerations::location_enum_type::LocationEnumType;
@@ -11,7 +13,8 @@ use crate::v2_0_1::enumerations::reading_context_enum_type::ReadingContextEnumTy
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SampledValueType {
-    pub value: f32,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision")]
+    pub value: Decimal,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<ReadingContextEnumType>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v2_0_1/datatypes/set_monitoring_data_type.rs
+++ b/src/v2_0_1/datatypes/set_monitoring_data_type.rs
@@ -1,3 +1,5 @@
+use rust_decimal::Decimal;
+
 use super::component_type::ComponentType;
 use super::variable_type::VariableType;
 use crate::v2_0_1::enumerations::monitor_enum_type::MonitorEnumType;
@@ -11,7 +13,8 @@ pub struct SetMonitoringDataType {
     pub id: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<bool>,
-    pub value: f32,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision")]
+    pub value: Decimal,
     #[serde(rename = "type")]
     pub kind: MonitorEnumType,
     pub severity: u8,

--- a/src/v2_0_1/datatypes/variable_characteristics_type.rs
+++ b/src/v2_0_1/datatypes/variable_characteristics_type.rs
@@ -1,3 +1,5 @@
+use rust_decimal::Decimal;
+
 use crate::v2_0_1::enumerations::data_enum_type::DataEnumType;
 
 /// Fixed read-only parameters of a variable.
@@ -9,9 +11,11 @@ pub struct VariableCharacteristicsType {
     pub unit: Option<String>,
     pub data_type: DataEnumType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_limit: Option<f32>,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision_option")]
+    pub min_limit: Option<Decimal>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_limit: Option<f32>,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision_option")]
+    pub max_limit: Option<Decimal>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub values_list: Option<String>,
     pub supports_monitoring: bool,

--- a/src/v2_0_1/datatypes/variable_monitoring_type.rs
+++ b/src/v2_0_1/datatypes/variable_monitoring_type.rs
@@ -1,3 +1,5 @@
+use rust_decimal::Decimal;
+
 use crate::v2_0_1::enumerations::monitor_enum_type::MonitorEnumType;
 
 /// A monitoring setting for a variable.
@@ -7,7 +9,8 @@ use crate::v2_0_1::enumerations::monitor_enum_type::MonitorEnumType;
 pub struct VariableMonitoringType {
     pub id: i32,
     pub transaction: bool,
-    pub value: f32,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision")]
+    pub value: Decimal,
     #[serde(rename = "type")]
     pub kind: MonitorEnumType,
     pub severity: u8,

--- a/src/v2_0_1/messages/cost_updated.rs
+++ b/src/v2_0_1/messages/cost_updated.rs
@@ -1,4 +1,5 @@
 //! CostUpdated
+use rust_decimal::Decimal;
 use validator::Validate;
 
 /// CostUpdatedRequest, sent by the CSMS to the Charging Station.
@@ -8,7 +9,8 @@ use validator::Validate;
 #[serde(rename_all = "camelCase")]
 pub struct CostUpdatedRequest {
     /// Current total cost, based on the information known by the CSMS, of the transaction including taxes. In the currency configured with the configuration Variable: [Currency]
-    pub total_cost: f32,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision")]
+    pub total_cost: Decimal,
     /// Transaction Id of the transaction the current cost are asked for.
     #[validate(length(min = 0, max = 36))]
     pub transaction_id: String,

--- a/src/v2_0_1/messages/transaction_event.rs
+++ b/src/v2_0_1/messages/transaction_event.rs
@@ -1,5 +1,6 @@
 use chrono::DateTime;
 use chrono::Utc;
+use rust_decimal::Decimal;
 
 use crate::v2_0_1::datatypes::evse_type::EVSEType;
 use crate::v2_0_1::datatypes::id_token_info_type::IdTokenInfoType;
@@ -40,7 +41,8 @@ pub struct TransactionEventRequest {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionEventResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub total_cost: Option<f32>,
+    #[serde(with = "rust_decimal::serde::arbitrary_precision_option")]
+    pub total_cost: Option<Decimal>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub charging_priority: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Decimal is now used to retain decimal accuracy. As per the requirements of the OCPP specification.

Fixes #109 