### PR TITLE
Fixes for serde rename error for sType3

### DIFF
--- a/src/v2_0_1/enumerations/connector_enum_type.rs
+++ b/src/v2_0_1/enumerations/connector_enum_type.rs
@@ -28,7 +28,7 @@ pub enum ConnectorEnumType {
     SCEE77,
     #[serde(rename = "sType2")]
     SType2,
-    #[serde(rename = "sType2")]
+    #[serde(rename = "sType3")]
     SType3,
     Other1PhMax16A,
     Other1PhOver16A,


### PR DESCRIPTION
This pull request includes an update to the `ConnectorEnumType` enumeration in the `src/v2_0_1/enumerations/connector_enum_type.rs` file. The most important change is the correction of the `serde` rename attribute for the `SType3` variant.

* [`src/v2_0_1/enumerations/connector_enum_type.rs`](diffhunk://#diff-2c415dcef2c028b1caebadd656608a10774cb861e5c452185eb9ac30785b5996L31-R31): Corrected the `serde` rename attribute for the `SType3` variant from `"sType2"` to `"sType3"`.