### PR TITLE
fix: data field in DataTransferRequest objects is optional

### DIFF
--- a/src/tests/schema_validation/v2_0_1.rs
+++ b/src/tests/schema_validation/v2_0_1.rs
@@ -871,10 +871,30 @@ mod tests {
         assert!(compiled.is_valid(&instance));
     }
     #[test]
+    fn validate_data_transfer_request_no_data() {
+        let test = DataTransferRequest {
+            message_id: Some("message_id".to_string()),
+            data: None,
+            vendor_id: "vendor_id".to_string(),
+        };
+        let schema = include_str!("schemas/v2.0.1/DataTransferRequest.json");
+        let schema = serde_json::from_str(schema).unwrap();
+        let instance = serde_json::to_value(test).unwrap();
+        let compiled = Validator::new(&schema).expect("A valid schema");
+        let result = compiled.validate(&instance);
+        if let Err(errors) = result {
+            for error in errors {
+                println!("Validation error: {}", error);
+                println!("Instance path: {}", error.instance_path);
+            }
+        }
+        assert!(compiled.is_valid(&instance));
+    }
+    #[test]
     fn validate_data_transfer_request() {
         let test = DataTransferRequest {
             message_id: Some("message_id".to_string()),
-            data: "data".to_string(),
+            data: Some("data".to_string()),
             vendor_id: "vendor_id".to_string(),
         };
         let schema = include_str!("schemas/v2.0.1/DataTransferRequest.json");
@@ -894,7 +914,7 @@ mod tests {
     fn validate_data_transfer_response() {
         let test = DataTransferResponse {
             status: DataTransferStatusEnumType::Accepted,
-            data: "".to_string(),
+            data: None,
             status_info: Some(StatusInfoType {
                 reason_code: "".to_string(),
                 additional_info: Some("".to_string()),

--- a/src/v2_0_1/messages/datatransfer.rs
+++ b/src/v2_0_1/messages/datatransfer.rs
@@ -13,7 +13,8 @@ pub struct DataTransferRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message_id: Option<String>,
     /// Data without specified length or format. This needs to be decided by both parties (Open to implementation).
-    pub data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
     /// This identifies the Vendor specific     implementation
     #[validate(length(min = 0, max = 255))]
     pub vendor_id: String,
@@ -26,7 +27,8 @@ pub struct DataTransferResponse {
     /// This indicates the success or failure of the data transfer.
     pub status: DataTransferStatusEnumType,
     /// Data without specified length or format, in response to request.
-    pub data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
     /// Detailed status information.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_info: Option<StatusInfoType>,


### PR DESCRIPTION
the `data` field on the `DataTransfer*` messages is optional

unfortunately a breaking change 😀 