### PR TITLE
fix(ocpp16): support both Celcius and Celsius units for MeterValues and StopTransaction messages

### DIFF
--- a/src/tests/schema_validation/v1_6.rs
+++ b/src/tests/schema_validation/v1_6.rs
@@ -1230,4 +1230,15 @@ mod tests {
         }
         assert!(compiled.is_valid(&instance));
     }
+    #[test]
+    fn test_unit_of_measure_deserialize_celcius_celsius() {
+        use crate::v1_6::types::UnitOfMeasure;
+        let json = r#""Celcius""#;
+        let unit: UnitOfMeasure = serde_json::from_str(json).unwrap();
+        assert_eq!(unit, UnitOfMeasure::Celsius);
+
+        let json = r#""Celsius""#;
+        let unit: UnitOfMeasure = serde_json::from_str(json).unwrap();
+        assert_eq!(unit, UnitOfMeasure::Celsius);
+    }
 }

--- a/src/v1_6/types/unit_of_measure.rs
+++ b/src/v1_6/types/unit_of_measure.rs
@@ -35,6 +35,8 @@ pub enum UnitOfMeasure {
     /// Voltage (r.m.s. AC).
     V,
     /// Degrees (temperature).
+    /// Also allow Celcius as an alias for compatibility - see OCPP 1.6 errata
+    #[serde(alias = "Celcius")]
     Celsius,
     /// Degrees (temperature).
     Fahrenheit,


### PR DESCRIPTION
Update to support both spellings.

Reference from OCPP 1.6j errata:
<img width="988" alt="image" src="https://github.com/user-attachments/assets/6a9d3119-0277-41b7-9fa7-ac41f1c649a6" />
