### PR TITLE
feat(v1_6): serialize chrono::DateTime just with fractional milliseconds

### DIFF
--- a/src/v1_6/helpers/datetime_rfc3339.rs
+++ b/src/v1_6/helpers/datetime_rfc3339.rs
@@ -1,0 +1,94 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Deserializer, Serializer};
+pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&date.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    DateTime::parse_from_rfc3339(&s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(serde::de::Error::custom)
+}
+
+pub mod option {
+    use chrono::{DateTime, SecondsFormat, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match date {
+            Some(dt) => serializer.serialize_str(&dt.to_rfc3339_opts(SecondsFormat::Millis, true)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<DateTime<Utc>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt = Option::<String>::deserialize(deserializer)?;
+        match opt {
+            Some(s) => DateTime::parse_from_rfc3339(&s)
+                .map(|dt| Some(dt.with_timezone(&Utc)))
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use serde_json;
+
+    #[test]
+    fn test_serialize_deserialize_datetime() {
+        let naive = Utc
+            .with_ymd_and_hms(2023, 9, 3, 12, 34, 56)
+            .unwrap()
+            .naive_utc();
+        let naive = naive
+            .checked_add_signed(chrono::Duration::milliseconds(789))
+            .unwrap();
+        let dt: DateTime<Utc> = DateTime::from_naive_utc_and_offset(naive, Utc);
+        let json = serde_json::to_string(&dt).unwrap();
+        let deserialized: DateTime<Utc> = serde_json::from_str(&json).unwrap();
+        assert_eq!(dt, deserialized);
+    }
+
+    #[test]
+    fn test_serialize_deserialize_option_some() {
+        let naive = Utc
+            .with_ymd_and_hms(2023, 9, 3, 12, 34, 56)
+            .unwrap()
+            .naive_utc();
+        let naive = naive
+            .checked_add_signed(chrono::Duration::milliseconds(789))
+            .unwrap();
+        let dt: DateTime<Utc> = DateTime::from_naive_utc_and_offset(naive, Utc);
+        let opt_dt = Some(dt);
+        let json = serde_json::to_string(&opt_dt).unwrap();
+        let deserialized: Option<DateTime<Utc>> =
+            option::deserialize(&mut serde_json::Deserializer::from_str(&json)).unwrap();
+        assert_eq!(opt_dt, deserialized);
+    }
+
+    #[test]
+    fn test_serialize_deserialize_option_none() {
+        let opt_dt: Option<DateTime<Utc>> = None;
+        let json = serde_json::to_string(&opt_dt).unwrap();
+        let deserialized: Option<DateTime<Utc>> =
+            option::deserialize(&mut serde_json::Deserializer::from_str(&json)).unwrap();
+        assert_eq!(opt_dt, deserialized);
+    }
+}

--- a/src/v1_6/helpers/mod.rs
+++ b/src/v1_6/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod datetime_rfc3339;

--- a/src/v1_6/messages/boot_notification.rs
+++ b/src/v1_6/messages/boot_notification.rs
@@ -38,6 +38,7 @@
 //! While in pending state, the following Central System initiated messages are not allowed:
 //! RemoteStartTransaction.req and RemoteStopTransaction.req
 
+use crate::v1_6::helpers::datetime_rfc3339;
 use crate::v1_6::types::RegistrationStatus;
 use chrono::{DateTime, Utc};
 use validator::Validate;
@@ -104,6 +105,7 @@ pub struct BootNotificationRequest {
 pub struct BootNotificationResponse {
     /// # From OCPP Specification
     /// Required. This contains the Central System’s current time.
+    #[serde(with = "datetime_rfc3339")]
     pub current_time: DateTime<Utc>,
 
     /// # From OCPP Specification

--- a/src/v1_6/messages/get_composite_schedule.rs
+++ b/src/v1_6/messages/get_composite_schedule.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 
+use crate::v1_6::helpers::datetime_rfc3339;
 use crate::v1_6::types::{ChargingRateUnitType, ChargingSchedule, GetCompositeScheduleStatus};
 
 /// This contains the field definition of the GetCompositeSchedule.req PDU sent by the Central System to theCharge Point. See also Get Composite Schedule
@@ -26,6 +27,7 @@ pub struct GetCompositeScheduleResponse {
     pub connector_id: Option<i32>,
     /// Optional. Time. Periods contained in the charging profile are relative to this point in time. If status is "Rejected", this field may be absent.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub schedule_start: Option<DateTime<Utc>>,
     /// Optional. Planned Composite Charging Schedule, the energy consumption over time. Always relative to ScheduleStart. If status is "Rejected", this field may be absent.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v1_6/messages/get_diagnostics.rs
+++ b/src/v1_6/messages/get_diagnostics.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use validator::Validate;
 
+use crate::v1_6::helpers::datetime_rfc3339;
+
 /// This contains the field definition of the GetDiagnostics.req PDU sent by the Central System to the Charge Point. See also Get Diagnostics
 #[derive(serde::Serialize, serde::Deserialize, Validate, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
@@ -15,9 +17,11 @@ pub struct GetDiagnosticsRequest {
     pub retry_interval: Option<i32>,
     /// Optional. This contains the date and time of the oldest logging information to include in the diagnostics.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub start_time: Option<DateTime<Utc>>,
     /// Optional. This contains the date and time of the latest logging information to include in the diagnostics.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub stop_time: Option<DateTime<Utc>>,
 }
 

--- a/src/v1_6/messages/heart_beat.rs
+++ b/src/v1_6/messages/heart_beat.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use validator::Validate;
 
+use crate::v1_6::helpers::datetime_rfc3339;
+
 #[derive(serde::Serialize, serde::Deserialize, Validate, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct HeartbeatRequest {}
@@ -10,5 +12,6 @@ pub struct HeartbeatRequest {}
 pub struct HeartbeatResponse {
     /// # From OCPP Specification
     /// Required. This contains the current time of the Central System.
+    #[serde(with = "datetime_rfc3339")]
     pub current_time: DateTime<Utc>,
 }

--- a/src/v1_6/messages/reserve_now.rs
+++ b/src/v1_6/messages/reserve_now.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 
 use validator::Validate;
 
+use crate::v1_6::helpers::datetime_rfc3339;
 use crate::v1_6::types::ReservationStatus;
 
 /// This contains the field definition of the ReserveNow.req PDU sent by the Central System to the Charge Point. See also Reserve Now
@@ -11,6 +12,7 @@ pub struct ReserveNowRequest {
     /// Required. This contains the id of the connector to be reserved. A value of 0 means that the reservation is not for a specific connector.
     pub connector_id: u32,
     /// Required. This contains the date and time when the reservation ends.
+    #[serde(with = "datetime_rfc3339")]
     pub expiry_date: DateTime<Utc>,
     /// Required. The identifier for which the Charge Point has to reserve a connector.
     #[validate(length(min = 1, max = 20))]

--- a/src/v1_6/messages/start_transaction.rs
+++ b/src/v1_6/messages/start_transaction.rs
@@ -1,3 +1,4 @@
+use crate::v1_6::helpers::datetime_rfc3339;
 use crate::v1_6::types::IdTagInfo;
 
 use chrono::{DateTime, Utc};
@@ -18,6 +19,7 @@ pub struct StartTransactionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reservation_id: Option<i32>,
     /// Required. This contains the date and time on which the transaction is started.
+    #[serde(with = "datetime_rfc3339")]
     pub timestamp: DateTime<Utc>,
 }
 

--- a/src/v1_6/messages/status_notification.rs
+++ b/src/v1_6/messages/status_notification.rs
@@ -1,3 +1,4 @@
+use crate::v1_6::helpers::datetime_rfc3339;
 use crate::v1_6::types::{ChargePointErrorCode, ChargePointStatus};
 
 use chrono::{DateTime, Utc};
@@ -19,6 +20,7 @@ pub struct StatusNotificationRequest {
     pub status: ChargePointStatus,
     /// Optional. The time for which the status is reported. If absent time of receipt of the message will be assumed.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub timestamp: Option<DateTime<Utc>>,
     /// Optional. This identifies the vendor-specific implementation.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v1_6/messages/stop_transaction.rs
+++ b/src/v1_6/messages/stop_transaction.rs
@@ -1,3 +1,4 @@
+use crate::v1_6::helpers::datetime_rfc3339;
 use crate::v1_6::types::{IdTagInfo, MeterValue, Reason};
 
 use chrono::{DateTime, Utc};
@@ -14,6 +15,7 @@ pub struct StopTransactionRequest {
     /// Optional. Only filled in when request applies to a specific connector.
     pub meter_stop: i32,
     /// Required. This contains the date and time on which the transaction is stopped.
+    #[serde(with = "datetime_rfc3339")]
     pub timestamp: DateTime<Utc>,
     /// Required. This contains the transaction-id as received by the StartTransactionResponse
     pub transaction_id: i32,

--- a/src/v1_6/messages/update_firmware.rs
+++ b/src/v1_6/messages/update_firmware.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use validator::Validate;
 
+use crate::v1_6::helpers::datetime_rfc3339;
+
 /// This contains the field definition of the UpdateFirmware.req PDU sent by the Central System to the Charge Point. See also Update Firmware
 #[derive(serde::Serialize, serde::Deserialize, Validate, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
@@ -11,6 +13,7 @@ pub struct UpdateFirmwareRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<i32>,
     /// Required. This contains the date and time after which the Charge Point is allowed to retrieve the (new) firmware.
+    #[serde(with = "datetime_rfc3339")]
     pub retrieve_date: DateTime<Utc>,
     /// Optional. The interval in seconds after which a retry may be attempted. If this field is not present, it is left to Charge Point to decide how long to wait between attempts.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/v1_6/mod.rs
+++ b/src/v1_6/mod.rs
@@ -9,3 +9,6 @@ pub mod messages;
 
 /// types
 pub mod types;
+
+/// helper functions
+pub mod helpers;

--- a/src/v1_6/types/charging_profile.rs
+++ b/src/v1_6/types/charging_profile.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use super::{
     ChargingProfileKindType, ChargingProfilePurposeType, ChargingSchedule, RecurrencyKindType,
 };
+use crate::v1_6::helpers::datetime_rfc3339;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
@@ -16,8 +17,10 @@ pub struct ChargingProfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recurrency_kind: Option<RecurrencyKindType>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub valid_from: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub valid_to: Option<DateTime<Utc>>,
     pub charging_schedule: ChargingSchedule,
 }

--- a/src/v1_6/types/charging_schedule.rs
+++ b/src/v1_6/types/charging_schedule.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 
 use super::{ChargingRateUnitType, ChargingSchedulePeriod};
+use crate::v1_6::helpers::datetime_rfc3339;
 
 /// Charging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and ChargingProfile.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Default)]
@@ -12,6 +13,7 @@ pub struct ChargingSchedule {
     pub duration: Option<i32>,
     /// Optional. Starting point of an absolute schedule. If absent the schedule will be relative to start of charging.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, deserialize_with = "datetime_rfc3339::option::deserialize")]
     pub start_schedule: Option<DateTime<Utc>>,
     /// Required. The unit of measure Limit is expressed in.
     pub charging_rate_unit: ChargingRateUnitType,

--- a/src/v1_6/types/id_tag_info.rs
+++ b/src/v1_6/types/id_tag_info.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 
 use super::AuthorizationStatus;
+use crate::v1_6::helpers::datetime_rfc3339;
 use validator::Validate;
 
 /// Contains status information about an identifier. It is returned in Authorize, Start Transaction and Stop Transaction responses. If expiryDate is not given, the status has no end date.
@@ -9,10 +10,11 @@ use validator::Validate;
 pub struct IdTagInfo {
     /// Optional. This contains the date at which idTag should be removed from the Authorization Cache.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "datetime_rfc3339::option")]
     pub expiry_date: Option<DateTime<Utc>>,
     /// Optional. This contains the parent-identifier. IdToken
     #[validate(length(min = 1, max = 20))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id_tag: Option<String>,
     /// Required. This contains whether the idTag has been accepted or not by the Central System.
     pub status: AuthorizationStatus,

--- a/src/v1_6/types/meter_value.rs
+++ b/src/v1_6/types/meter_value.rs
@@ -2,12 +2,14 @@ use chrono::DateTime;
 use chrono::Utc;
 
 use super::SampledValue;
+use crate::v1_6::helpers::datetime_rfc3339;
 
 /// Collection of one or more sampled values in MeterValues.req and StopTransaction.req. All sampled values in a MeterValue are sampled at the same point in time.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MeterValue {
     /// Required. Timestamp for measured value(s).
+    #[serde(with = "datetime_rfc3339")]
     pub timestamp: DateTime<Utc>,
     /// Required. One or more measured values
     pub sampled_value: Vec<SampledValue>,


### PR DESCRIPTION
Hi,

thank you for this very useful crate.

Please consider merging this patch.

Some backends, at least charge.sk, can't decode more precise timestamps and discard the message.

It shall not hurt anything, 1 millisecond timestamp precision shall be more then enough for this application.
